### PR TITLE
fixed the podspec and pushed it to our new private specs repo 

### DIFF
--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -2,12 +2,18 @@ Pod::Spec.new do |s|
   s.name         = 'PopTop'
   s.version      = '0.0.4'
   s.summary      = 'A simple way to return canned responses'
-  s.homepage     = 'https://github.com/bellycard/poptop'
-  s.license      = 'MIT'
-  s.author       = { 'AJ Self': 'aj.self3@gmail.com' }
+  s.homepage     = 'http://www.bellycard.com'  
+  
+  s.license      = { :type => 'MIT', :text => <<-LICENSE
+    This license text is required or else CocoaPods gets upset.
+    LICENSE
+  }
+  s.author       = { 'AJ Self' => 'aj.self3@gmail.com' }
   s.platform     = :ios, '8.0'
 
-  s.source       = { git: 'https://github.com/bellycard/PopTop.git', tag: '0.0.4' }
+  s.source       = { :git => 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', :tag => '0.0.4' }
+  
+  s.dependency 'SwiftyJSON', '~> 2.3'
 
   s.source_files  = 'Source/*.swift'
 


### PR DESCRIPTION
ugh
https://guides.cocoapods.org/making/private-cocoapods.html
https://github.com/bellycard/PrivatePodSpecs

I also think I'll have to update the version tag. This should allow circleci to build barco again.
