### PR TITLE
Allow poptop to handle URLs with IDs

### DIFF
--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'PopTop'
-  s.version      = '0.0.5'
+  s.version      = '0.0.6'
   s.summary      = 'A simple way to return canned responses'
   s.homepage     = 'https://www.bellycard.com'  
   
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { 'AJ Self': 'aj.self3@gmail.com' }
   s.platform     = :ios, '8.0'
 
-  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.5' }
+  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.6' }
   
   s.dependency 'SwiftyJSON', '~> 2.3'
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.5</string>
+	<string>0.0.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -94,8 +94,6 @@ public class Manager: NSURLProtocol {
             if Int(component) != nil {
                 // if it does, remove the number and replace with predetermined key
                 pathComponents[index] = ":id"
-                pathComponents.removeFirst()
-                break
             }
         }
 

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -21,7 +21,25 @@ public class Manager: NSURLProtocol {
     // MARK: - Protocol implementation
     // Class
     override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
-        if let requestName = resourceNameAndIDFromURL(request.URL!).name, _ = resources[requestName] {
+        var components = request.URL?.pathComponents
+        var resourceName: String?
+
+        // Check if the URL has an ID within it -> /api/path/to/123/example
+        for (index, component) in components!.enumerate() {
+            if Int(component) != nil {
+                // if it does, remove the number and replace with predetermined key
+                components![index] = ":id"
+                components!.removeFirst()
+                resourceName = "/\(components!.joinWithSeparator("/"))"
+                break
+            }
+        }
+
+        if resourceName == nil {
+            resourceName = resourceNameAndIDFromURL(request.URL!).name
+        }
+
+        if resources[resourceName!] != nil {
             return true
         }
         
@@ -86,8 +104,6 @@ public class Manager: NSURLProtocol {
         
         if let idProvided = Int(url.lastPathComponent!) {
             id = idProvided
-            // Remove the ID from the route so the path to the resource can become its key like so:
-            // /users/123/pets/456 -> ["/users/123/pets": ["456": NSData]]
             pathComponents.removeLast()
         }
         

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -83,7 +83,6 @@ public class Manager: NSURLProtocol {
         var name: String?
         var id: Int?
         let separator = "/"
-        var resourceName: String?
         
         if let idProvided = Int(url.lastPathComponent!) {
             id = idProvided
@@ -96,7 +95,6 @@ public class Manager: NSURLProtocol {
                 // if it does, remove the number and replace with predetermined key
                 pathComponents[index] = ":id"
                 pathComponents.removeFirst()
-                resourceName = "/\(pathComponents.joinWithSeparator("/"))"
                 break
             }
         }

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -21,25 +21,7 @@ public class Manager: NSURLProtocol {
     // MARK: - Protocol implementation
     // Class
     override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
-        var components = request.URL?.pathComponents
-        var resourceName: String?
-
-        // Check if the URL has an ID within it -> /api/path/to/123/example
-        for (index, component) in components!.enumerate() {
-            if Int(component) != nil {
-                // if it does, remove the number and replace with predetermined key
-                components![index] = ":id"
-                components!.removeFirst()
-                resourceName = "/\(components!.joinWithSeparator("/"))"
-                break
-            }
-        }
-
-        if resourceName == nil {
-            resourceName = resourceNameAndIDFromURL(request.URL!).name
-        }
-
-        if resources[resourceName!] != nil {
+        if let requestName = resourceNameAndIDFromURL(request.URL!).name, _ = resources[requestName] {
             return true
         }
         
@@ -101,12 +83,24 @@ public class Manager: NSURLProtocol {
         var name: String?
         var id: Int?
         let separator = "/"
+        var resourceName: String?
         
         if let idProvided = Int(url.lastPathComponent!) {
             id = idProvided
             pathComponents.removeLast()
         }
-        
+
+        // Check if the URL has an ID within it -> /api/path/to/123/example
+        for (index, component) in pathComponents.enumerate() {
+            if Int(component) != nil {
+                // if it does, remove the number and replace with predetermined key
+                pathComponents[index] = ":id"
+                pathComponents.removeFirst()
+                resourceName = "/\(pathComponents.joinWithSeparator("/"))"
+                break
+            }
+        }
+
         // prevents "//" from occurring when joining the path components
         if pathComponents.first == separator {
             pathComponents.removeFirst()

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -69,6 +69,20 @@ class ManagerTests: XCTestCase {
         XCTAssertTrue(result, "PopTop should handle a known host")
     }
 
+    func testShouldReturnTrueForPathsWithID() {
+        // Given
+        let testResource = ResourceWithData(resourceIdentifier: "/path/to/:id/example")
+        manager.addResources(testResource)
+        NSURLProtocol.registerClass(PopTop.Manager)
+        let testRequest = NSURLRequest(URL: NSURL(string: "https://api.example.com/path/to/123/example")!)
+
+        // When
+        let result = manager.canInitWithRequest(testRequest)
+
+        // Then
+        XCTAssertTrue(result, "PopTop should handle :id in paths")
+    }
+
     func testShouldReturnFalseForUnknownPath() {
         // Given
         manager.addResources(ResourceWithData(resourceIdentifier: "/path/to/first"), ResourceWithData(resourceIdentifier: "/path/to/second"))

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -72,15 +72,19 @@ class ManagerTests: XCTestCase {
     func testShouldReturnTrueForPathsWithID() {
         // Given
         let testResource = ResourceWithData(resourceIdentifier: "/path/to/:id/example")
-        manager.addResources(testResource)
+        let testResource2 = ResourceWithData(resourceIdentifier: "/path/to/:id/example/with/:id/another")
         NSURLProtocol.registerClass(PopTop.Manager)
+        manager.addResources(testResource, testResource2)
         let testRequest = NSURLRequest(URL: NSURL(string: "https://api.example.com/path/to/123/example")!)
+        let testRequest2 = NSURLRequest(URL: NSURL(string: "https://api.example.com/path/to/123/example/with/456/another")!)
 
         // When
         let result = manager.canInitWithRequest(testRequest)
+        let result2 = manager.canInitWithRequest(testRequest2)
 
         // Then
         XCTAssertTrue(result, "PopTop should handle :id in paths")
+        XCTAssertTrue(result2, "PopTop should handle :id in paths")
     }
 
     func testShouldReturnFalseForUnknownPath() {

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,6 @@ dependencies:
     # this list exists because CircleCI's version of xctool might not always be the latest
     # the pre-build step forces an update to the latest
     - brew uninstall xctool && brew install --HEAD xctool
-    - git submodule update --init --recursive
     # https://circleci.com/docs/ios#upgrading-cocoapods
     - sudo gem install cocoapods --version 0.39.0
     # CocoaPods sometimes has issues using caches


### PR DESCRIPTION
@bellycard/mobile This allows you to do stuff like this

Handles any URL like this:
/api/rewards/123/purchases
/api/rewards/456/purchases
/api/rewards/789/purchases
`RedeemReward(resourceIdentifier: "/api/rewards/:id/purchases")`
