### PR TITLE
Return multiple IDs

### DIFF
--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'PopTop'
-  s.version      = '0.0.6'
+  s.version      = '0.0.7'
   s.summary      = 'A simple way to return canned responses'
   s.homepage     = 'https://www.bellycard.com'  
   
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { 'AJ Self': 'aj.self3@gmail.com' }
   s.platform     = :ios, '8.0'
 
-  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.6' }
+  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.7' }
   
   s.dependency 'SwiftyJSON', '~> 2.3'
 

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.6</string>
+	<string>0.0.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -78,21 +78,21 @@ public class Manager: NSURLProtocol {
     
     /// Normalize a path which can be used as a Resource Identifier and requested resource ID, if available.
     /// - Returns: "/path/to/resource/123" -> ("/path/to/resource/", 123)
-    static func resourceNameAndIDFromURL(url: NSURL) -> (name: String?, id: Int?) {
+    static func resourceNameAndIDFromURL(url: NSURL) -> (name: String?, ids: [Int]?) {
         var pathComponents = url.pathComponents!
         var name: String?
-        var id: Int?
+        var ids = [Int]?()
         let separator = "/"
-        
-        if let idProvided = Int(url.lastPathComponent!) {
-            id = idProvided
-            pathComponents.removeLast()
-        }
 
         // Check if the URL has an ID within it -> /api/path/to/123/example
         for (index, component) in pathComponents.enumerate() {
-            if Int(component) != nil {
-                // if it does, remove the number and replace with predetermined key
+            if let id = Int(component) {
+                // if it does, add it to the IDs array to be returned
+                if ids?.append(id) == nil {
+                    ids = [id]
+                }
+                
+                // if it does, remove the number and replace with predetermined key to be used for the name to be returned
                 pathComponents[index] = ":id"
             }
         }
@@ -105,6 +105,6 @@ public class Manager: NSURLProtocol {
         name = pathComponents.joinWithSeparator(separator)
         name = separator + name!
         
-        return (name, id)
+        return (name, ids)
     }
 }

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -87,13 +87,15 @@ public class Manager: NSURLProtocol {
         // Check if the URL has an ID within it -> /api/path/to/123/example
         for (index, component) in pathComponents.enumerate() {
 
-            // if it does, add it to the IDs array to be returned
+            // if it does...
             if let id = Int(component) {
+
+                // add it to the IDs array to be returned
                 if ids?.append(id) == nil {
                     ids = [id]
                 }
                 
-                // if it does, remove the number and replace with predetermined key to be used for the name to be returned
+                // remove the number and replace with predetermined key to be used for the name to be returned
                 pathComponents[index] = ":id"
             }
         }

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -86,8 +86,9 @@ public class Manager: NSURLProtocol {
 
         // Check if the URL has an ID within it -> /api/path/to/123/example
         for (index, component) in pathComponents.enumerate() {
+
+            // if it does, add it to the IDs array to be returned
             if let id = Int(component) {
-                // if it does, add it to the IDs array to be returned
                 if ids?.append(id) == nil {
                     ids = [id]
                 }

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -128,6 +128,31 @@ class ManagerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(nameAndID.name!, "/path/to/resource", "Relative path should be returned")
-        XCTAssertNil(nameAndID.id, "ID should be nil")
+        XCTAssertNil(nameAndID.ids, "ID should be nil")
+    }
+
+    func testResourceNameAndIDFromURLShouldReturnSingleID() {
+        // Given
+        let url = NSURL(string: "/path/123/to/resource")
+
+        // When
+        let nameAndIDs = Manager.resourceNameAndIDFromURL(url!)
+
+        // Then
+        XCTAssertEqual(nameAndIDs.name!, "/path/:id/to/resource", "Relative path should be returned")
+        XCTAssertEqual(nameAndIDs.ids!, [123], "Correct ID should be returned")
+
+    }
+
+    func testResourceNameAndIDFromURLShouldReturnMultipleIDs() {
+        // Given
+        let url = NSURL(string: "/path/123/to/resource/456")
+
+        // When
+        let nameAndIDs = Manager.resourceNameAndIDFromURL(url!)
+
+        // Then
+        XCTAssertEqual(nameAndIDs.name!, "/path/:id/to/resource/:id", "Relative path should be returned")
+        XCTAssertEqual(nameAndIDs.ids!, [123, 456], "Two IDs, in order, should be returned")
     }
 }


### PR DESCRIPTION
@bellycard/mobile 

This could have been a hangover when PopTop was trying to intelligently cache resource object instances. If a given RESTful URL has multiple IDs, they should be returned. For now, an array seems like the simplest, most straightforward way.
