### PR TITLE
Automatically fill which github tag is relevant. Add in correct homepage

### DIFF
--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = 'PopTop'
   s.version      = '0.0.7'
   s.summary      = 'A simple way to return canned responses'
-  s.homepage     = 'https://www.bellycard.com'  
+  s.homepage     = 'https://github.com/bellycard/PopTop'  
   
   s.license      = { type: 'MIT', text: <<-LICENSE
     This license text is required or else CocoaPods gets upset.
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { 'AJ Self': 'aj.self3@gmail.com' }
   s.platform     = :ios, '8.0'
 
-  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.7' }
+  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: s.version.to_s }
   
   s.dependency 'SwiftyJSON', '~> 2.3'
 


### PR DESCRIPTION
@bellycard/mobile minor stuff. 
