### PR TITLE
Pass resource details tuple to data method

### DIFF
--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'PopTop'
-  s.version      = '0.0.7'
+  s.version      = '0.0.8'
   s.summary      = 'A simple way to return canned responses'
   s.homepage     = 'https://github.com/bellycard/PopTop'  
   

--- a/PopTop.podspec
+++ b/PopTop.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.name         = 'PopTop'
   s.version      = '0.0.7'
   s.summary      = 'A simple way to return canned responses'
-  s.homepage     = 'https://www.bellycard.com'  
+  s.homepage     = 'https://github.com/bellycard/PopTop'  
   
   s.license      = { type: 'MIT', text: <<-LICENSE
     This license text is required or else CocoaPods gets upset.
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.author       = { 'AJ Self': 'aj.self3@gmail.com' }
   s.platform     = :ios, '8.0'
 
-  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: '0.0.7' }
+  s.source       = { git: 'https://02e34411c57bedacd7b5e66d60efaa3b9ffbc346@github.com/bellycard/PopTop.git', tag: s.version.to_s }
   
   s.dependency 'SwiftyJSON', '~> 2.3'
 

--- a/Source/ImageResource.swift
+++ b/Source/ImageResource.swift
@@ -33,7 +33,7 @@ public struct ImageResource: ResourceProtocol {
         self.resourceIdentifier = resourceIdentifier
     }
     
-    public func data(request: NSURLRequest) -> NSData {
+    public func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
         return imageRepresentation!
     }
 }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.7</string>
+	<string>0.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/JSONFromFile.swift
+++ b/Source/JSONFromFile.swift
@@ -19,7 +19,7 @@ public struct JSONFromFile: ResourceProtocol {
         self.resourceIdentifier = resourceIdentifier
     }
 
-    public func data(request: NSURLRequest) -> NSData {
+    public func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
         return try! json.rawData()
     }
 }

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -32,7 +32,7 @@ public class Manager: NSURLProtocol {
 
     override public func startLoading() {
         /// A tuple of (key, id) that will be used within the registry dict based on the URL path
-        /// `/path/to/resource/123` -> `("/path/to/resource", 123)`
+        /// `/path/to/resource/123` -> `(name: "/path/to/resource", ids: [123])`
         let pathToResourceParts = Manager.resourceNameAndIDFromURL(request.URL!)
         
         /// The Resource itself, if available.
@@ -44,7 +44,7 @@ public class Manager: NSURLProtocol {
         precondition(resource != nil, "Resource not found")
 
         /// Data that will be returned in the HTTP request.
-        let dataToReturn = resource!.data(request)
+        let dataToReturn = resource!.data(request, resourceDetails: pathToResourceParts)
 
         let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Type": resource!.contentType])!
 

--- a/Source/ResourceProtocol.swift
+++ b/Source/ResourceProtocol.swift
@@ -19,5 +19,5 @@ public protocol ResourceProtocol {
 
      - Returns: NSData representation of object to be returned
      */
-    func data(request: NSURLRequest) -> NSData
+    func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData
 }

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -34,8 +34,9 @@ class ManagerTests: XCTestCase {
             self.resourceIdentifier = resourceIdentifier
         }
 
-        func data(request: NSURLRequest) -> NSData {
-            let testData: JSON = [["id": "123", "foo": "bar"]]
+        func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
+            let id = resourceDetails.ids!.first!
+            let testData: JSON = [["id": id, "foo": "bar"]]
             return try! testData.rawData()
         }
     }

--- a/Tests/ResourceCollectionTests.swift
+++ b/Tests/ResourceCollectionTests.swift
@@ -17,7 +17,7 @@ class ResourceCollectionTests: XCTestCase {
             let resourceIdentifier = "/path/to/resource"
             let contentType = "fake type"
 
-            func data(request: NSURLRequest) -> NSData {
+            func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
                 return NSData()
             }
         }
@@ -38,7 +38,7 @@ class ResourceCollectionTests: XCTestCase {
             let resourceIdentifier = "/path/to/resource"
             let contentType = "fake type"
 
-            func data(request: NSURLRequest) -> NSData {
+            func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
                 return NSData()
             }
         }
@@ -47,7 +47,7 @@ class ResourceCollectionTests: XCTestCase {
             let resourceIdentifier = "/path/to/second/resource"
             let contentType = "test content type"
             
-            func data(request: NSURLRequest) -> NSData {
+            func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
                 return NSData()
             }
         }
@@ -71,7 +71,7 @@ class ResourceCollectionTests: XCTestCase {
             let resourceIdentifier = "/path/to/resource"
             let contentType = "fake type"
 
-            func data(request: NSURLRequest) -> NSData {
+            func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
                 return NSData()
             }
         }


### PR DESCRIPTION
@bellycard/mobile 

Could really help so you can do things like

``` swift
class Foo: ResourceProtocol {
  // Attributes and init...

  // Return data
  func data(request: NSURLRequest, resourceDetails: (name: String?, ids: [Int]?)) -> NSData {
    let name = resourceDetails.name!

    if name == "/some/path/:id" {
      let id = resourceDetails.ids!.first!
      let testData: JSON = [["id": id, "foo": "bar"]]
      return try! testData.rawData()
    } else if name == "/some/path/:id/with/:id/more" {
      let id = resourceDetails.ids!.last!
      let testData: JSON = [["id": id, "foo": "bar"]]
      return try! testData.rawData()
    }
  }
}
```

Which would then allow you to map multiple routes to the same class and not have to rely on that class instance pulling apart the request URL when PopTop did that already for free.
