### PR TITLE
Reindent to 2 spaces. Add support for POST HTTP Body parsing

### DIFF
--- a/PopTop.xcodeproj/project.pbxproj
+++ b/PopTop.xcodeproj/project.pbxproj
@@ -42,7 +42,7 @@
 		D13C39491BCBF7FE0044B40D /* PopTopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PopTopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D13C394E1BCBF7FE0044B40D /* ManagerTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ManagerTests.swift; sourceTree = "<group>"; tabWidth = 4; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D13C39501BCBF7FE0044B40D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D13C39591BCBF84B0044B40D /* Manager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Manager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D13C39591BCBF84B0044B40D /* Manager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Manager.swift; sourceTree = "<group>"; };
 		D1403FA41C5BC54E003D4631 /* String+IsBlankTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+IsBlankTests.swift"; sourceTree = "<group>"; };
 		D16A39F21BE9220C003D830D /* JSONFromFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONFromFile.swift; sourceTree = "<group>"; };
 		D195252E1C52D2100006442D /* String+IsBlank.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+IsBlank.swift"; sourceTree = "<group>"; };

--- a/PopTop.xcodeproj/project.pbxproj
+++ b/PopTop.xcodeproj/project.pbxproj
@@ -40,7 +40,7 @@
 		D13C39421BCBF7FE0044B40D /* PopTop.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PopTop.h; sourceTree = "<group>"; };
 		D13C39441BCBF7FE0044B40D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D13C39491BCBF7FE0044B40D /* PopTopTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PopTopTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D13C394E1BCBF7FE0044B40D /* ManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ManagerTests.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		D13C394E1BCBF7FE0044B40D /* ManagerTests.swift */ = {isa = PBXFileReference; indentWidth = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ManagerTests.swift; sourceTree = "<group>"; tabWidth = 4; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D13C39501BCBF7FE0044B40D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D13C39591BCBF84B0044B40D /* Manager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = Manager.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		D1403FA41C5BC54E003D4631 /* String+IsBlankTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+IsBlankTests.swift"; sourceTree = "<group>"; };

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -10,7 +10,7 @@ import SwiftyJSON
 
 // Module wide types
 public typealias BodyArtifacts = [String: [String]]
-public typealias IDArtifacts = [Int]
+public typealias IDArtifacts = ContiguousArray<Int>
 public typealias NameArtifact = String
 public typealias QueryArtifacts = [String: [String]]
 public typealias ResourceArtifacts = (body: BodyArtifacts?, ids: IDArtifacts?, query: QueryArtifacts?)
@@ -96,7 +96,7 @@ public class Manager: NSURLProtocol {
       var pathComponents = url.pathComponents else { return nil }
 
     var name: String?
-    var ids = [Int]?()
+    var ids = ContiguousArray<Int>?()
     let separator = "/"
 
     // Check if the URL has an ID within it -> /api/path/to/123/example
@@ -130,11 +130,10 @@ public class Manager: NSURLProtocol {
   }
 
   /// Return a dictionary with arrays populated with the values of HTTP body data. URLs allow keys to be declared multiple times, hence the array container.
-  static func ArtifactDictionaryFromData(data: NSData?) -> QueryArtifacts? {
+  private static func ArtifactDictionaryFromData(data: NSData?) -> QueryArtifacts? {
     guard let data = data,
-      let componentString = String(data: data, encoding: NSUTF8StringEncoding)
-      else {
-        return nil
+          let componentString = String(data: data, encoding: NSUTF8StringEncoding) else {
+              return nil
     }
 
     return ArtifactDictionaryFromString(componentString)
@@ -142,15 +141,15 @@ public class Manager: NSURLProtocol {
 
   // inspired by https://gist.github.com/freerunnering/1215df277d750af71887
   /// Return a dictionary with arrays populated with the values of query parameters. URLs allow keys to be declared multiple times, hence the array container.
-  static func ArtifactDictionaryFromString(string: String?) -> QueryArtifacts? {
+  private static func ArtifactDictionaryFromString(string: String?) -> QueryArtifacts? {
     guard let string = string else { return nil }
 
     var queryDict = QueryArtifacts()
 
-    for kVString in string.componentsSeparatedByString("&") {
-      let parts = kVString.componentsSeparatedByString("=")
+    for keyValueString in string.componentsSeparatedByString("&") {
+      let parts = keyValueString.componentsSeparatedByString("=")
 
-      guard parts.count > 1 else { continue }
+      if parts.count < 2 { continue }
 
       let key = parts.first!.stringByRemovingPercentEncoding!
       let value = parts.last!.stringByRemovingPercentEncoding!

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -10,7 +10,7 @@ import SwiftyJSON
 
 // Module wide types
 public typealias BodyArtifacts = [String: [String]]
-public typealias IDArtifacts = ContiguousArray<Int>
+public typealias IDArtifacts = [Int]
 public typealias NameArtifact = String
 public typealias QueryArtifacts = [String: [String]]
 public typealias ResourceArtifacts = (body: BodyArtifacts?, ids: IDArtifacts?, query: QueryArtifacts?)
@@ -96,7 +96,7 @@ public class Manager: NSURLProtocol {
       var pathComponents = url.pathComponents else { return nil }
 
     var name: String?
-    var ids = ContiguousArray<Int>?()
+    var ids = IDArtifacts?()
     let separator = "/"
 
     // Check if the URL has an ID within it -> /api/path/to/123/example

--- a/Source/Manager.swift
+++ b/Source/Manager.swift
@@ -9,144 +9,159 @@
 import SwiftyJSON
 
 // Module wide types
-public typealias QueryArtifacts = [String: [String]]
+public typealias BodyArtifacts = [String: [String]]
 public typealias IDArtifacts = [Int]
 public typealias NameArtifact = String
-public typealias ResourceArtifacts = (ids: IDArtifacts?, query: QueryArtifacts?)
+public typealias QueryArtifacts = [String: [String]]
+public typealias ResourceArtifacts = (body: BodyArtifacts?, ids: IDArtifacts?, query: QueryArtifacts?)
 
 public class Manager: NSURLProtocol {
-    // MARK: - Properties
-    
-    // Holds instances of Resource subclasses and are used to check if Manager can handle an incoming request
-    private static var resources = ResourceCollection<String, ResourceProtocol>()
+  // MARK: - Properties
 
-    static var count: Int {
-        return resources.count
-    }
-    
-    // MARK: - Protocol implementation
-    // Class
-    override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
-        let requestName = resourceArtifactsFromURL(request.URL!)!.name
+  // Holds instances of Resource subclasses and are used to check if Manager can handle an incoming request
+  private static var resources = ResourceCollection<String, ResourceProtocol>()
 
-        if resources[requestName] != nil {
-            return true
-        }
-        
-        return false
-    }
-    
-    // MARK: - Instance
+  static var count: Int {
+    return resources.count
+  }
 
-    override public func startLoading() {
-        /// A tuple of (key, id, query) that will be used within the registry dict based on the URL path
-        /// `/path/to/resource/123` -> `(name: "/path/to/resource", ids: [123], query: ["foo": ["bar"]])`
-        let resourceArtifacts = Manager.resourceArtifactsFromURL(request.URL!)
-        
-        /// The Resource itself
-        /// This is used to create new represetnations of a requested resource
-        let resource = Manager.resources[resourceArtifacts!.name]
+  // MARK: - Protocol implementation
+  // Class
+  override public class func canInitWithRequest(request: NSURLRequest) -> Bool {
+    // TODO: guard statement
+    let requestName = resourceArtifactsFromRequest(request)!.name
 
-        /// Data that will be returned in the HTTP response.
-        /// The `name` is not returned as it is identicical to the `resourceIdentifier` on the `resource` instance
-        let dataToReturn = resource!.data(request, resourceArtifacts: (ids: resourceArtifacts!.ids, query: resourceArtifacts!.query))
-
-        let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Type": resource!.contentType])!
-
-        client?.URLProtocol(self, didReceiveResponse: response, cacheStoragePolicy: .NotAllowed)
-        client?.URLProtocol(self, didLoadData: dataToReturn)
-        client?.URLProtocolDidFinishLoading(self)
-    }
-    
-    /// Because PopTop always returns an object it is acceptable to leave this empty.
-    override public func stopLoading() {}
-    
-    /// Returns unchanged request
-    override public class func canonicalRequestForRequest(request: NSURLRequest) -> NSURLRequest {
-        return request
+    if resources[requestName] != nil {
+      return true
     }
 
-    // MARK: - Class
+    return false
+  }
 
-    /// Receives a variable amount of ResourceProtocol types that are queried when receiving an HTTP request
-    static public func addResources(resourcesToAdd: ResourceProtocol...) {
-        for resource in resourcesToAdd {
-            resources[resource.resourceIdentifier] = resource
-        }
+  // MARK: - Instance
+
+  override public func startLoading() {
+    /// A tuple of (key, id, query) that will be used within the registry dict based on the URL path
+    /// `/path/to/resource/123` -> `(name: "/path/to/resource", ids: [123], query: ["foo": ["bar"]])`
+    let resourceArtifacts = Manager.resourceArtifactsFromRequest(request)
+
+    /// The Resource itself
+    /// This is used to create new represetnations of a requested resource
+    let resource = Manager.resources[resourceArtifacts!.name]
+
+    /// Data that will be returned in the HTTP response.
+    /// The `name` is not returned as it is identicical to the `resourceIdentifier` on the `resource` instance
+    let dataToReturn = resource!.data(request, resourceArtifacts: (ids: resourceArtifacts!.ids, query: resourceArtifacts!.query, body: resourceArtifacts!.body))
+
+    let response = NSHTTPURLResponse(URL: request.URL!, statusCode: 200, HTTPVersion: "HTTP/1.1", headerFields: ["Content-Type": resource!.contentType])!
+
+    client?.URLProtocol(self, didReceiveResponse: response, cacheStoragePolicy: .NotAllowed)
+    client?.URLProtocol(self, didLoadData: dataToReturn)
+    client?.URLProtocolDidFinishLoading(self)
+  }
+
+  /// Because PopTop always returns an object it is acceptable to leave this empty.
+  override public func stopLoading() {}
+
+  /// Returns unchanged request
+  override public class func canonicalRequestForRequest(request: NSURLRequest) -> NSURLRequest {
+    return request
+  }
+
+  // MARK: - Class
+
+  /// Receives a variable amount of ResourceProtocol types that are queried when receiving an HTTP request
+  static public func addResources(resourcesToAdd: ResourceProtocol...) {
+    for resource in resourcesToAdd {
+      resources[resource.resourceIdentifier] = resource
     }
+  }
 
-    /// Remove a resource from the manager
-    static public func removeResource(resource: ResourceProtocol) {
-        resources.remove(resource.resourceIdentifier)
-    }
+  /// Remove a resource from the manager
+  static public func removeResource(resource: ResourceProtocol) {
+    resources.remove(resource.resourceIdentifier)
+  }
 
-    /// Remove all resources from the manager
-    static public func removeResources() {
-        resources.removeAll()
-    }
-    
-    // MARK: - Helpers
-    
-    /// Normalize a path which can be used as a Resource Identifier and requested resource IDs, if available.
-    /// - Returns: "/path/to/resource/123?foo=bar&baz=quux" -> ("/path/to/resource/", 123, ["foo": ["bar"], "baz": ["quux"])
-    static func resourceArtifactsFromURL(url: NSURL) -> (name: NameArtifact, ids: IDArtifacts?, query: QueryArtifacts?)? {
-        guard var pathComponents = url.pathComponents else { return nil }
+  /// Remove all resources from the manager
+  static public func removeResources() {
+    resources.removeAll()
+  }
 
-        var name: String?
-        var ids = [Int]?()
-        let separator = "/"
+  // MARK: - Helpers
 
-        // Check if the URL has an ID within it -> /api/path/to/123/example
-        for (index, component) in pathComponents.enumerate() {
+  /// Normalize a path which can be used as a Resource Identifier and requested resource IDs, if available.
+  /// - Returns: "/path/to/resource/123?foo=bar&baz=quux" -> ("/path/to/resource/", 123, ["foo": ["bar"], "baz": ["quux"])
+  static func resourceArtifactsFromRequest(request: NSURLRequest) -> (name: NameArtifact, ids: IDArtifacts?, query: QueryArtifacts?, body: BodyArtifacts?)? {
+    guard let url = request.URL,
+      var pathComponents = url.pathComponents else { return nil }
 
-            // if it does...
-            if let id = Int(component) {
+    var name: String?
+    var ids = [Int]?()
+    let separator = "/"
 
-                // add it to the IDs array to be returned
-                if ids?.append(id) == nil {
-                    ids = [id]
-                }
-                
-                // remove the number and replace with predetermined key to be used for the name to be returned
-                pathComponents[index] = ":id"
-            }
+    // Check if the URL has an ID within it -> /api/path/to/123/example
+    for (index, component) in pathComponents.enumerate() {
+
+      // if it does...
+      if let id = Int(component) {
+
+        // add it to the IDs array to be returned
+        if ids?.append(id) == nil {
+          ids = [id]
         }
 
-        // prevents "//" from occurring when joining the path components
-        if pathComponents.first == separator {
-            pathComponents.removeFirst()
-        }
-        
-        name = pathComponents.joinWithSeparator(separator)
-        name = separator + name!
-
-        let query = queryDictionaryFromURL(url)
-        
-        return (name!, ids, query)
+        // remove the number and replace with predetermined key to be used for the name to be returned
+        pathComponents[index] = ":id"
+      }
     }
 
-    // inspired by https://gist.github.com/freerunnering/1215df277d750af71887
-    /// Return a dictionary with arrays populated with the values of query parameters. URLs allow keys to be declared multiple times, hence the array container.
-    static func queryDictionaryFromURL(url: NSURL) -> QueryArtifacts? {
-        guard let query = url.query else { return nil }
-
-        var queryDict = QueryArtifacts()
-
-        for kVString in query.componentsSeparatedByString("&") {
-            let parts = kVString.componentsSeparatedByString("=")
-
-            guard parts.count > 1 else { continue }
-
-            let key = parts.first!.stringByRemovingPercentEncoding!
-            let value = parts.last!.stringByRemovingPercentEncoding!
-            var values = queryDict[key] ?? [String]()
-
-            if !value.isBlank {
-                values.append(value)
-                queryDict[key] = values
-            }
-        }
-
-        return queryDict
+    // prevents "//" from occurring when joining the path components
+    if pathComponents.first == separator {
+      pathComponents.removeFirst()
     }
+
+    name = pathComponents.joinWithSeparator(separator)
+    name = separator + name!
+
+    let body = ArtifactDictionaryFromData(request.HTTPBody)
+    let query = ArtifactDictionaryFromString(url.query)
+
+    return (name!, ids, query, body)
+  }
+
+  /// Return a dictionary with arrays populated with the values of HTTP body data. URLs allow keys to be declared multiple times, hence the array container.
+  static func ArtifactDictionaryFromData(data: NSData?) -> QueryArtifacts? {
+    guard let data = data,
+      let componentString = String(data: data, encoding: NSUTF8StringEncoding)
+      else {
+        return nil
+    }
+
+    return ArtifactDictionaryFromString(componentString)
+  }
+
+  // inspired by https://gist.github.com/freerunnering/1215df277d750af71887
+  /// Return a dictionary with arrays populated with the values of query parameters. URLs allow keys to be declared multiple times, hence the array container.
+  static func ArtifactDictionaryFromString(string: String?) -> QueryArtifacts? {
+    guard let string = string else { return nil }
+
+    var queryDict = QueryArtifacts()
+
+    for kVString in string.componentsSeparatedByString("&") {
+      let parts = kVString.componentsSeparatedByString("=")
+
+      guard parts.count > 1 else { continue }
+
+      let key = parts.first!.stringByRemovingPercentEncoding!
+      let value = parts.last!.stringByRemovingPercentEncoding!
+      var values = queryDict[key] ?? [String]()
+
+      if !value.isBlank {
+        values.append(value)
+        queryDict[key] = values
+      }
+    }
+
+    return queryDict
+  }
 }

--- a/Tests/ManagerTests.swift
+++ b/Tests/ManagerTests.swift
@@ -220,44 +220,44 @@ class ManagerTests: XCTestCase {
 
     // Skip this test for now due to a bug where HTTPBody is set to nil when PopTop receives the NSURLRequest
     // http://openradar.appspot.com/15993891
-    func xtestResourceArtifactsFromRequestShouldReturnBodyData() {
-        let testRequest = NSMutableURLRequest(URL: NSURL(string: "https://example.com/path/to/123/resource")!)
-        let session = NSURLSession.sharedSession()
-        let params = ["id": "123", "name": "Test User"]
-        let expect = expectationWithDescription("Test")
-
-        testRequest.HTTPMethod = "POST"
-        testRequest.HTTPBody = try! NSJSONSerialization.dataWithJSONObject(params, options: NSJSONWritingOptions())
-        testRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        testRequest.addValue("application/json", forHTTPHeaderField: "Accept")
-
-        NSURLProtocol.registerClass(PopTop.Manager)
-
-        struct TestPostResource: ResourceProtocol {
-            let resourceIdentifier = "/path/to/:id/resource"
-            let contentType = "fake type"
-
-            func data(request: NSURLRequest, resourceArtifacts: ResourceArtifacts) -> NSData {
-                let body = resourceArtifacts.body!
-                XCTAssertEqual(body["id"]!, ["123"], "Post data should be parsed into a dictionary")
-                return NSData()
-            }
-        }
-
-        manager.addResources(TestPostResource())
-
-        let task = session.dataTaskWithRequest(testRequest) { _,_,_ in
-            expect.fulfill()
-        }
-
-        task.resume()
-
-        waitForExpectationsWithTimeout(task.originalRequest!.timeoutInterval) { err in
-            if let err = err {
-                print("ERROR: \(err.localizedDescription)")
-            }
-
-            task.cancel()
-        }
-    }
+//    func testResourceArtifactsFromRequestShouldReturnBodyData() {
+//        let testRequest = NSMutableURLRequest(URL: NSURL(string: "https://example.com/path/to/123/resource")!)
+//        let session = NSURLSession.sharedSession()
+//        let params = ["id": "123", "name": "Test User"]
+//        let expect = expectationWithDescription("Test")
+//
+//        testRequest.HTTPMethod = "POST"
+//        testRequest.HTTPBody = try! NSJSONSerialization.dataWithJSONObject(params, options: NSJSONWritingOptions())
+//        testRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+//        testRequest.addValue("application/json", forHTTPHeaderField: "Accept")
+//
+//        NSURLProtocol.registerClass(PopTop.Manager)
+//
+//        struct TestPostResource: ResourceProtocol {
+//            let resourceIdentifier = "/path/to/:id/resource"
+//            let contentType = "fake type"
+//
+//            func data(request: NSURLRequest, resourceArtifacts: ResourceArtifacts) -> NSData {
+//                let body = resourceArtifacts.body!
+//                XCTAssertEqual(body["id"]!, ["123"], "Post data should be parsed into a dictionary")
+//                return NSData()
+//            }
+//        }
+//
+//        manager.addResources(TestPostResource())
+//
+//        let task = session.dataTaskWithRequest(testRequest) { _,_,_ in
+//            expect.fulfill()
+//        }
+//
+//        task.resume()
+//
+//        waitForExpectationsWithTimeout(task.originalRequest!.timeoutInterval) { err in
+//            if let err = err {
+//                print("ERROR: \(err.localizedDescription)")
+//            }
+//
+//            task.cancel()
+//        }
+//    }
 }


### PR DESCRIPTION
@bellycard/ios Lots of renaming and fixing indents. The meat of this PR is seen at the bottom in Tests/ManagerTests.swift. Please note it is a pending test because of a bug I can't work around at the moment. The functionality does work though and was tested locally. Although PopTop does not have a demo app at the moment I have tested it in another and it performs as expected.

This test came out of a need to refactor resourceArtifactsFromURL to become resourceArtifactsFromRequest located in Source/Manager.swift. This enables PopTop to parse POST HTTPBody data.
